### PR TITLE
Replace existing regular npm installs with clean installs

### DIFF
--- a/android/android-production-build.yml
+++ b/android/android-production-build.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Android app
         run: eas build --platform android --local --output ${{ github.workspace }}/app-release.aab

--- a/ios/ios-production-build.yml
+++ b/ios/ios-production-build.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build iOS app
         run: eas build --platform ios --local --non-interactive --output ${{ github.workspace }}/app-release.ipa


### PR DESCRIPTION
Each of the workflows currently makes use of `npm install` to install any dependencies, replacing with `npm ci`, or clean install, is generally faster and recommended for CI. [Some more info](https://docs.npmjs.com/cli/v6/commands/npm-ci#description)