### PR TITLE
Update version of setup-node, setup-java, upload-artifact actions

### DIFF
--- a/android/android-apk-build.yml
+++ b/android/android-apk-build.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18.x
           cache: 'npm'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         run: eas build --platform android --profile preview --local --output ${{ github.workspace }}/app-release.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app-release
           path: ${{ github.workspace }}/app-release.apk

--- a/android/android-development-build.yml
+++ b/android/android-development-build.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18.x
           cache: 'npm'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         run: eas build --platform android --profile development --local --output ${{ github.workspace }}/app-release.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app-release
           path: ${{ github.workspace }}/app-release.apk

--- a/android/android-production-build.yml
+++ b/android/android-production-build.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18.x
           cache: 'npm'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         run: eas build --platform android --local --output ${{ github.workspace }}/app-release.aab
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app-release
           path: ${{ github.workspace }}/app-release.aab

--- a/ios/ios-production-build.yml
+++ b/ios/ios-production-build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18.x
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
         run: eas build --platform ios --local --non-interactive --output ${{ github.workspace }}/app-release.ipa
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app-release
           path: ${{ github.workspace }}/app-release.ipa


### PR DESCRIPTION
## description
<!-- Please describe what changes you have made -->
Hey, I updated the versions of some of the actions, since they are older and use Node.js 16, which is deprecated. Cool project, it was useful for me!

## checklist:
<!-- Place an x in the box to check the following that apply -->
- [ ] New feature
- [X] Bug fix
- [ ] Tested locally
